### PR TITLE
[#19] Detecção automática de moeda local

### DIFF
--- a/__tests__/detectCurrency.test.ts
+++ b/__tests__/detectCurrency.test.ts
@@ -1,0 +1,59 @@
+import { detectLocalCurrency, getDefaultCurrencyPair } from '@/utils/detectCurrency';
+
+// Mock expo-localization
+jest.mock('expo-localization', () => ({
+  getLocales: jest.fn(),
+}));
+
+import * as Localization from 'expo-localization';
+const mockGetLocales = Localization.getLocales as jest.Mock;
+
+describe('detectLocalCurrency()', () => {
+  it('detecta BRL para região BR', () => {
+    mockGetLocales.mockReturnValue([{ regionCode: 'BR', languageTag: 'pt-BR' }]);
+    expect(detectLocalCurrency()).toBe('BRL');
+  });
+
+  it('detecta USD para região US', () => {
+    mockGetLocales.mockReturnValue([{ regionCode: 'US', languageTag: 'en-US' }]);
+    expect(detectLocalCurrency()).toBe('USD');
+  });
+
+  it('detecta EUR para região DE', () => {
+    mockGetLocales.mockReturnValue([{ regionCode: 'DE', languageTag: 'de-DE' }]);
+    expect(detectLocalCurrency()).toBe('EUR');
+  });
+
+  it('usa languageTag quando regionCode ausente', () => {
+    mockGetLocales.mockReturnValue([{ regionCode: null, languageTag: 'pt-BR' }]);
+    expect(detectLocalCurrency()).toBe('BRL');
+  });
+
+  it('retorna BRL como fallback para região desconhecida', () => {
+    mockGetLocales.mockReturnValue([{ regionCode: 'ZZ', languageTag: 'xx-ZZ' }]);
+    expect(detectLocalCurrency()).toBe('BRL');
+  });
+
+  it('retorna BRL quando getLocales lança erro', () => {
+    mockGetLocales.mockImplementation(() => { throw new Error('unavailable'); });
+    expect(detectLocalCurrency()).toBe('BRL');
+  });
+});
+
+describe('getDefaultCurrencyPair()', () => {
+  it('retorna USD→BRL para usuário brasileiro', () => {
+    mockGetLocales.mockReturnValue([{ regionCode: 'BR', languageTag: 'pt-BR' }]);
+    expect(getDefaultCurrencyPair()).toEqual({ from: 'USD', to: 'BRL' });
+  });
+
+  it('retorna USD→EUR para usuário europeu', () => {
+    mockGetLocales.mockReturnValue([{ regionCode: 'DE', languageTag: 'de-DE' }]);
+    expect(getDefaultCurrencyPair()).toEqual({ from: 'USD', to: 'EUR' });
+  });
+
+  it('evita par USD→USD (fallback para BRL)', () => {
+    mockGetLocales.mockReturnValue([{ regionCode: 'US', languageTag: 'en-US' }]);
+    const pair = getDefaultCurrencyPair();
+    expect(pair.from).not.toBe(pair.to);
+  });
+});

--- a/app.json
+++ b/app.json
@@ -31,7 +31,8 @@
       "favicon": "./assets/favicon.png"
     },
     "plugins": [
-      "expo-router"
+      "expo-router",
+      "expo-localization"
     ]
   }
 }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -31,6 +31,7 @@ export default function HomeScreen() {
     swapCurrencies,
     fetchRates,
     loadFavorites,
+    initPrefs,
     toggleFavorite,
     favorites,
   } = useCurrencyStore();
@@ -54,8 +55,8 @@ export default function HomeScreen() {
   );
 
   useEffect(() => {
+    initPrefs().then(() => fetchRates());
     loadFavorites();
-    fetchRates();
   }, []);
 
   const handleRefresh = useCallback(async () => {

--- a/app/alerts/index.tsx
+++ b/app/alerts/index.tsx
@@ -71,7 +71,7 @@ export default function AlertsScreen() {
           </Text>
           <Switch
             value={item.active && !triggered}
-            onValueChange={() => !triggered && toggleAlert(item.id)}
+            onValueChange={() => { if (!triggered) toggleAlert(item.id); }}
             trackColor={{ false: '#e5e7eb', true: '#bfdbfe' }}
             thumbColor={item.active ? '#37517e' : '#9ca3af'}
           />

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "buffer": "^6.0.3",
         "expo": "~55",
         "expo-linking": "~55.0.14",
+        "expo-localization": "~55.0.13",
         "expo-router": "^55.0.13",
         "expo-status-bar": "~55.0.5",
         "react": "19.2.0",
@@ -6094,6 +6095,19 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-localization": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-55.0.13.tgz",
+      "integrity": "sha512-fXiEUUihIrXmAEzoneaTOFcQ7TKmr25RR/ymrB/MvYTVnmevFA1zY2KI0VSiXY+NKKjZ8mG65YSn1wh4gEYKxA==",
+      "license": "MIT",
+      "dependencies": {
+        "rtl-detect": "^1.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "55.0.18",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-55.0.18.tgz",
@@ -11095,6 +11109,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "buffer": "^6.0.3",
     "expo": "~55",
     "expo-linking": "~55.0.14",
+    "expo-localization": "~55.0.13",
     "expo-router": "^55.0.13",
     "expo-status-bar": "~55.0.5",
     "react": "19.2.0",

--- a/src/store/currencyStore.ts
+++ b/src/store/currencyStore.ts
@@ -1,8 +1,15 @@
 import { create } from 'zustand';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getRates, RatesPayload } from '@/services/api';
+import { getDefaultCurrencyPair } from '@/utils/detectCurrency';
 
 const FAVORITES_KEY = 'favorites_v1';
+const PREFS_KEY = 'currency_prefs_v1';
+
+interface SavedPrefs {
+  fromCurrency: string;
+  toCurrency: string;
+}
 
 interface CurrencyState {
   // Converter
@@ -30,6 +37,7 @@ interface CurrencyState {
   fetchRates: () => Promise<void>;
   toggleFavorite: (pair: string) => void;
   loadFavorites: () => Promise<void>;
+  initPrefs: () => Promise<void>;
 }
 
 async function persistFavorites(favorites: string[]): Promise<void> {
@@ -38,6 +46,13 @@ async function persistFavorites(favorites: string[]): Promise<void> {
   } catch {
     // non-critical
   }
+}
+
+async function persistPrefs(from: string, to: string): Promise<void> {
+  try {
+    const prefs: SavedPrefs = { fromCurrency: from, toCurrency: to };
+    await AsyncStorage.setItem(PREFS_KEY, JSON.stringify(prefs));
+  } catch {}
 }
 
 export const useCurrencyStore = create<CurrencyState>((set, get) => ({
@@ -57,9 +72,15 @@ export const useCurrencyStore = create<CurrencyState>((set, get) => ({
 
   setAmount: (amount) => set({ amount }),
 
-  setFromCurrency: (code) => set({ fromCurrency: code }),
+  setFromCurrency: (code) => {
+    set({ fromCurrency: code });
+    persistPrefs(code, get().toCurrency);
+  },
 
-  setToCurrency: (code) => set({ toCurrency: code }),
+  setToCurrency: (code) => {
+    set({ toCurrency: code });
+    persistPrefs(get().fromCurrency, code);
+  },
 
   swapCurrencies: () => {
     const { fromCurrency, toCurrency } = get();
@@ -107,6 +128,28 @@ export const useCurrencyStore = create<CurrencyState>((set, get) => ({
       }
     } catch {
       set({ favoritesLoaded: true });
+    }
+  },
+
+  /**
+   * Inicializa preferências de moeda:
+   * - Se já existe prefs salvo → restaura última escolha do usuário
+   * - Se primeira abertura → detecta moeda local automaticamente
+   */
+  initPrefs: async () => {
+    try {
+      const raw = await AsyncStorage.getItem(PREFS_KEY);
+      if (raw) {
+        const prefs = JSON.parse(raw) as SavedPrefs;
+        set({ fromCurrency: prefs.fromCurrency, toCurrency: prefs.toCurrency });
+      } else {
+        // Primeira abertura: detectar moeda local
+        const { from, to } = getDefaultCurrencyPair();
+        set({ fromCurrency: from, toCurrency: to });
+        await persistPrefs(from, to);
+      }
+    } catch {
+      // fallback silencioso: mantém USD→BRL
     }
   },
 }));

--- a/src/utils/detectCurrency.ts
+++ b/src/utils/detectCurrency.ts
@@ -1,0 +1,89 @@
+import * as Localization from 'expo-localization';
+
+/**
+ * Mapa de região (ISO 3166-1 alpha-2) → código de moeda ISO 4217.
+ * Cobre os principais mercados relevantes para o app.
+ */
+const REGION_TO_CURRENCY: Record<string, string> = {
+  BR: 'BRL', // Brasil
+  US: 'USD', // Estados Unidos
+  GB: 'GBP', // Reino Unido
+  DE: 'EUR', // Alemanha
+  FR: 'EUR', // França
+  IT: 'EUR', // Itália
+  ES: 'EUR', // Espanha
+  PT: 'EUR', // Portugal
+  NL: 'EUR', // Holanda
+  BE: 'EUR', // Bélgica
+  AT: 'EUR', // Áustria
+  JP: 'JPY', // Japão
+  CN: 'CNY', // China
+  AU: 'AUD', // Austrália
+  CA: 'CAD', // Canadá
+  CH: 'CHF', // Suíça
+  MX: 'MXN', // México
+  AR: 'ARS', // Argentina
+  CL: 'CLP', // Chile
+  CO: 'COP', // Colômbia
+  PE: 'PEN', // Peru
+  UY: 'UYU', // Uruguai
+  BO: 'BOB', // Bolívia
+  IN: 'INR', // Índia
+  KR: 'KRW', // Coreia do Sul
+  SG: 'SGD', // Singapura
+  HK: 'HKD', // Hong Kong
+  NO: 'NOK', // Noruega
+  SE: 'SEK', // Suécia
+  DK: 'DKK', // Dinamarca
+  NZ: 'NZD', // Nova Zelândia
+  ZA: 'ZAR', // África do Sul
+  TR: 'TRY', // Turquia
+  RU: 'RUB', // Rússia
+  PL: 'PLN', // Polônia
+  CZ: 'CZK', // República Tcheca
+  HU: 'HUF', // Hungria
+};
+
+const FIRST_OPEN_KEY = 'first_open_done';
+const DEFAULT_FROM = 'USD';
+const DEFAULT_TO = 'BRL';
+
+/**
+ * Detecta a moeda local do dispositivo via locale/região.
+ * Retorna o código ISO 4217 ou 'BRL' como fallback.
+ */
+export function detectLocalCurrency(): string {
+  try {
+    const locales = Localization.getLocales();
+    for (const locale of locales) {
+      // Tenta pela região explícita (ex: pt-BR → BR)
+      if (locale.regionCode) {
+        const currency = REGION_TO_CURRENCY[locale.regionCode];
+        if (currency) return currency;
+      }
+      // Tenta extrair região do languageTag (ex: "pt-BR" → "BR")
+      const parts = locale.languageTag.split('-');
+      const region = parts[parts.length - 1]?.toUpperCase();
+      if (region && region.length === 2) {
+        const currency = REGION_TO_CURRENCY[region];
+        if (currency) return currency;
+      }
+    }
+  } catch {
+    // expo-localization falhou — usar fallback
+  }
+  return DEFAULT_TO;
+}
+
+/**
+ * Retorna o par padrão para primeira abertura.
+ * fromCurrency: USD (base universal)
+ * toCurrency: moeda local detectada
+ */
+export function getDefaultCurrencyPair(): { from: string; to: string } {
+  const localCurrency = detectLocalCurrency();
+  return {
+    from: DEFAULT_FROM,
+    to: localCurrency === DEFAULT_FROM ? DEFAULT_TO : localCurrency,
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,9 @@
     "paths": {
       "@/*": ["src/*"]
     }
-  }
+  },
+  "exclude": [
+    "node_modules",
+    "functions"
+  ]
 }


### PR DESCRIPTION
## Resumo
- Detecta moeda do país do usuário via `expo-localization` na primeira abertura
- Mapa com 36 regiões → ISO 4217 (BR→BRL, US→USD, DE→EUR, JP→JPY...)
- Aberturas seguintes restauram última escolha (AsyncStorage)
- Fallback silencioso para USD→BRL se região desconhecida

## Testes
- 9 casos unitários cobrindo detecção, fallbacks, languageTag e par padrão
- 48/48 passando

## Como testar
1. Apagar o app (limpar AsyncStorage)
2. Abrir → deve carregar par baseado na região do dispositivo
3. Trocar moeda → fechar → abrir → deve restaurar a última escolha

Closes #19

🤖 Generated with [Claude Code](https://claude.ai/claude-code)